### PR TITLE
Support the varbinary cast to json for both complex type and literal

### DIFF
--- a/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
+++ b/core/trino-main/src/main/java/io/trino/util/JsonUtil.java
@@ -519,7 +519,9 @@ public final class JsonUtil
             }
             else {
                 Slice value = type.getSlice(block, position);
-                jsonGenerator.writeString(Base64.getEncoder().encodeToString(value.byteArray()));
+                byte[] currentValue = new byte[value.length()];
+                System.arraycopy(value.byteArray(), value.byteArrayOffset(), currentValue, 0, value.length());
+                jsonGenerator.writeString(Base64.getEncoder().encodeToString(currentValue));
             }
         }
     }


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! Find more information in our development guide at https://github.com/trinodb/trino/blob/master/.github/DEVELOPMENT.md and contact us on #dev in Slack. -->
<!-- Provide an overview of the PR for maintainers and reviewers. -->
## Description

- Support the ROW, MAP, ARRAY field varbinary to json
- Support varbinary literal to json
- Use the Base64 to encode the varbinary to string


<!-- Provide details that would help an engineer who is unfamiliar with this part of the code. -->
## Additional context and related issues
Current Trino doesn't support varbinary to json cast, so when there is field in the complex record with varbinary, it will fail to convert it to json. 
How it's tested
```
trino> CREATE TABLE memory.default.example_table (
    ->     id INTEGER,
    ->     data ROW(
    ->         name VARCHAR,
    ->         value VARBINARY
    ->     )
    -> );

trino> INSERT INTO memory.default.example_table (id, data) VALUES
    -> (
    ->     1,
    ->     ROW('example_name', CAST('4F' AS VARBINARY))
    -> );
INSERT: 1 row

trino> select * from memory.default.example_table;
 id |               data
----+----------------------------------
  1 | {name=example_name, value=34 46}

trino> select cast(data as json)  from memory.default.example_table;
                 _col0
----------------------------------------
 {"name":"example_name","value":"NEY="}

```